### PR TITLE
Fix issue: Handle no service found

### DIFF
--- a/src/rosgraph_monitor/observer.py
+++ b/src/rosgraph_monitor/observer.py
@@ -60,7 +60,10 @@ class ServiceObserver(Observer):
         self.name = service_name
         self.type = service_type
         self.client = None
-        self.start_service()
+        try:
+            self.start_service()
+        except:
+            print("{} service not started".format(self.name))
         super(ServiceObserver, self).__init__(name, loop_rate_hz)
 
     def start_service(self):


### PR DESCRIPTION
@ipa-hsd thanks for the changes. I can now start the rosgraph observer but I get now another issue:

```
/get_rossystem_model service not started
starting ROSGraphObserver...
Exception in thread Thread-15:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/nhg/rosin-paper/catkin_ws/src/rosgraph_monitor/src/rosgraph_monitor/observer.py", line 35, in _run
    status_msgs = self.generate_diagnostics()
  File "/home/nhg/rosin-paper/catkin_ws/src/rosgraph_monitor/src/rosgraph_monitor/observer.py", line 80, in generate_diagnostics
    resp = self.client.call()
AttributeError: 'NoneType' object has no attribute 'call'
```

and when I kill a node listed in the [metacontrol_desired.rossystem](https://github.com/rosin-project/rosgraph_monitor/blob/ab6cdeb39d2e09a1a7a6e2da415d34143ab215d0/resources/metacontrol_desired.rossystem) file I don't get error message from diagnostics.